### PR TITLE
feat: Add YouTube transcript server

### DIFF
--- a/packages/package-list.json
+++ b/packages/package-list.json
@@ -102,5 +102,13 @@
     "sourceUrl": "https://github.com/MindscapeHQ/mcp-server-raygun",
     "homepage": "https://raygun.com",
     "license": "MIT"
+  },
+  {
+    "name": "@kimtaeyoon83/mcp-server-youtube-transcript",
+    "description": "This is an MCP server that allows you to directly download transcripts of YouTube videos.",
+    "vendor": "Freddie (https://github.com/kimtaeyoon83)",
+    "sourceUrl": "https://github.com/kimtaeyoon83/mcp-server-youtube-transcript",
+    "homepage": "https://github.com/kimtaeyoon83/mcp-server-youtube-transcript",
+    "license": "MIT"
   }
 ]


### PR DESCRIPTION
feat: Add YouTube transcript server
Add new MCP server for extracting YouTube video transcripts:
- Implement transcript extraction functionality

The server provides:
- Transcript extraction from YouTube URLs/IDs
- Multi-language support

This MCP server does not have any specific environment variables or configurations.