### PR TITLE
Add node runtime to @automatalabs/mcp-server-playwright

### DIFF
--- a/packages/package-list.json
+++ b/packages/package-list.json
@@ -249,6 +249,8 @@
     "vendor": "Automata Labs (https://automatalabs.io)",
     "sourceUrl": "https://github.com/Automata-Labs-team/MCP-Server-Playwright/tree/main",
     "homepage": "https://github.com/Automata-Labs-team/MCP-Server-Playwright",
+    "runtime": "node",
+    "license": "MIT"
   },
   {
     "name": "@mcp-get-community/server-llm-txt",


### PR DESCRIPTION
Add runtime and license information to `@automatalabs/mcp-server-playwright` package entry in `packages/package-list.json`.

* Add `"runtime": "node"` to the `@automatalabs/mcp-server-playwright` package entry
* Add `"license": "MIT"` to the `@automatalabs/mcp-server-playwright` package entry

