### PR TITLE
Add mcp-k8s server

### DIFF
--- a/packages/package-list.json
+++ b/packages/package-list.json
@@ -322,5 +322,14 @@
     "homepage": "https://llmindset.co.uk/resources/hfspace-connector/",
     "license": "MIT",
     "runtime": "node"
+  },
+  {
+    "name": "@strowk/mcp-k8s",
+    "description": "MCP server connecting to Kubernetes",
+    "vendor": "Timur Sultanaev (https://str4.io/about-me)",
+    "sourceUrl": "https://github.com/strowk/mcp-k8s-go",
+    "homepage": "https://github.com/strowk/mcp-k8s-go",
+    "license": "MIT",
+    "runtime": "node"
   }
 ]


### PR DESCRIPTION
I made a server for connecting to Kubernetes and a bunch of tools to get pods, services, logs, events, etc.
It is written actually in Golang, but I have wrapped prebuilt binaries into npm package and tested such distribution with both inspector and Claude Desktop, works like a charm :)

There are even functional autotests - https://github.com/strowk/mcp-k8s-go/tree/main/testdata/with_k3d