### PR TITLE
feat: add custom commands to helpers

### DIFF
--- a/src/types/package.ts
+++ b/src/types/package.ts
@@ -23,6 +23,10 @@ export interface PackageHelper {
     };
     configureEnv?: (config: any) => Promise<void>;
     runtime?: 'node' | 'python';
+    customCommand?: {
+        command: string;
+        args?: string[];
+    }
 }
 
 export interface PackageHelpers {

--- a/src/utils/config-manager.ts
+++ b/src/utils/config-manager.ts
@@ -103,7 +103,7 @@ export class ConfigManager {
         return serverName in (config.mcpServers || {});
     }
 
-    static async installPackage(pkg: Package, envVars?: Record<string, string>): Promise<void> {
+    static async installPackage(pkg: Package, envVars?: Record<string, string>, customCommand?: Record<string, any>): Promise<void> {
         const config = this.readConfig();
         const serverName = pkg.name.replace(/\//g, '-');
         
@@ -114,11 +114,21 @@ export class ConfigManager {
 
         // Add command and args based on runtime
         if (pkg.runtime === 'node') {
-            serverConfig.command = 'npx';
-            serverConfig.args = ['-y', pkg.name];
+            if (customCommand) {
+                serverConfig.command = customCommand.command;
+                serverConfig.args = customCommand.args || [];
+            } else {
+                serverConfig.command = 'npx';
+                serverConfig.args = ['-y', pkg.name];
+            }
         } else if (pkg.runtime === 'python') {
-            serverConfig.command = 'uvx';
-            serverConfig.args = [pkg.name];
+            if (customCommand) {
+                serverConfig.command = customCommand.command;
+                serverConfig.args = customCommand.args || [];
+            } else {
+                serverConfig.command = 'uvx';
+                serverConfig.args = [pkg.name];
+            }
         }
 
         config.mcpServers[serverName] = serverConfig;

--- a/src/utils/package-management.ts
+++ b/src/utils/package-management.ts
@@ -226,8 +226,9 @@ export async function installPackage(pkg: Package): Promise<void> {
     }
 
     const envVars = await promptForEnvVars(pkg.name);
+    const customCommand = packageHelpers[pkg.name]?.customCommand;
     
-    await ConfigManager.installPackage(pkg, envVars);
+    await ConfigManager.installPackage(pkg, envVars, customCommand);
     console.log('Updated Claude desktop configuration');
 
     // Check analytics consent and track if allowed


### PR DESCRIPTION
- Adds `customCommand` as an optional type for helpers
- Given the user doesn't need to care about this, it's not included in inquirer prompts
- If customCommand exists it is given preference for install into configs

Tested it with the aforementioned `npx kips serve` problem in #34 and installed properly.