### PR TITLE
Add MCP server to integrate with Stability AI's image models

### DIFF
--- a/packages/package-list.json
+++ b/packages/package-list.json
@@ -439,5 +439,14 @@
     "homepage": "https://github.com/ChanMeng666/server-google-news",
     "license": "MIT",
     "runtime": "node"
+  },
+  {
+    "name": "mcp-server-stability-ai",
+    "description": "Integrates Stability AI's image generation and manipulation capabilities for editing, upscaling, and more via Stable Diffusion models.",
+    "vendor": "Tadas Antanavicius (https://github.com/tadasant)",
+    "sourceUrl": "https://github.com/tadasant/mcp-server-stability-ai",
+    "homepage": "https://www.pulsemcp.com/servers/tadasant-stability-ai",
+    "license": "MIT",
+    "runtime": "node"
   }
 ]

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -185,5 +185,17 @@ export const packageHelpers: PackageHelpers = {
         required: true
       }
     }
+  },
+  'mcp-server-stability-ai': {
+    requiredEnvVars: {
+      STABILITY_AI_API_KEY: {
+        description: 'API key for Stability AI; get it from https://platform.stability.ai/account/keys.',
+        required: true
+      },
+      IMAGE_STORAGE_DIRECTORY: {
+        description: 'Directory on filesystem to store output images.',
+        required: true
+      }
+    }
   }
 };

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -193,7 +193,7 @@ export const packageHelpers: PackageHelpers = {
         required: true
       },
       IMAGE_STORAGE_DIRECTORY: {
-        description: 'Directory on filesystem to store output images.',
+        description: 'Absolute path to a directory on filesystem to store output images.',
         required: true
       }
     }


### PR DESCRIPTION
# Description

An MCP server that integrates [Stability AI's](https://stability.ai/) image generation and manipulation capabilities for editing, upscaling, and more via Stable Diffusion models.

# Server Details

README [on the repository](https://github.com/tadasant/mcp-server-stability-ai) is pretty thorough, but here's a snippet of the tools:

| Tool Name            | Description                                                                                        |
| -------------------- | -------------------------------------------------------------------------------------------------- |
| `generate-image`     | Generate a high quality image of anything based on a provided prompt & other optional parameters.  |
| `remove-background`  | Remove the background from an image.                                                               |
| `outpaint`           | Extend an image in any direction while maintaining visual consistency.                             |
| `search-and-replace` | Replace objects or elements in an image by describing what to replace and what to replace it with. |
| `upscale-fast`       | Enhance image resolution by 4x.                                                                    |
| `upscale-creative`   | Enhance image resolution up to 4K.                                                                 |
| `control-sketch`     | Translate hand-drawn sketch to production-grade image.                                             |
