### PR TITLE
Preserve other config options when updating mcpServers

### DIFF
--- a/src/utils/config-manager.ts
+++ b/src/utils/config-manager.ts
@@ -12,6 +12,7 @@ export interface MCPServer {
 
 export interface MCPConfig {
     mcpServers: Record<string, MCPServer>;
+    [key: string]: any;  // Allow other config options
 }
 
 export interface MCPPreferences {
@@ -52,6 +53,7 @@ export class ConfigManager {
             }
             const config = JSON.parse(fs.readFileSync(this.configPath, 'utf8'));
             return {
+                ...config,
                 mcpServers: config.mcpServers || {}
             };
         } catch (error) {


### PR DESCRIPTION
It looks like the `claude_desktop_config.json` file contains other config besides the `mcpServers` object.  Mcp-get was clearing my config, specifically the `globalShortcut` option. This PR changes it so that other config options are preserved.