### PR TITLE
feat: add two new Wrale LTD MCP servers to package list

### DIFF
--- a/packages/mcp-server-make.json
+++ b/packages/mcp-server-make.json
@@ -1,0 +1,10 @@
+{
+  "name": "mcp-server-make",
+  "description": "A Model Context Protocol server that provides make target calling functionality. This server enables LLMs to execute make targets from a specified Makefile within a specified working directory.",
+  "vendor": "Wrale LTD (https://wrale.com)",
+  "sourceUrl": "https://github.com/wrale/mcp-server-make",
+  "homepage": "https://github.com/wrale/mcp-server-make",
+  "license": "MIT",
+  "runtime": "python",
+  "environmentVariables": {}
+}

--- a/packages/mcp-server-tree-sitter.json
+++ b/packages/mcp-server-tree-sitter.json
@@ -1,0 +1,10 @@
+{
+  "name": "mcp-server-tree-sitter",
+  "description": "A Model Context Protocol server that provides code analysis capabilities using tree-sitter. This server enables LLMs to explore, search, and analyze code with appropriate context management.",
+  "vendor": "Wrale LTD (https://wrale.com)",
+  "sourceUrl": "https://github.com/wrale/mcp-server-tree-sitter",
+  "homepage": "https://github.com/wrale/mcp-server-tree-sitter",
+  "license": "MIT",
+  "runtime": "python",
+  "environmentVariables": {}
+}


### PR DESCRIPTION
Add Wrale LTD's mcp-server-make and mcp-server-tree-sitter servers to the MCP package registry. 

The make server enables LLMs to execute make targets from Makefiles, providing build system integration for AI assistants.
* Repo: https://github.com/wrale/mcp-server-make
* Docs: https://github.com/wrale/mcp-server-make/blob/main/docs/index.md

The tree-sitter server provides code analysis capabilities, enabling LLMs to explore, search, and analyze code with appropriate context management.
* Repo: https://github.com/wrale/mcp-server-tree-sitter
* Docs:
  * https://github.com/wrale/mcp-server-tree-sitter/blob/main/README.md
  * https://github.com/wrale/mcp-server-tree-sitter/blob/main/FEATURES.md