### PR TITLE
Add anilist-mcp server

### DIFF
--- a/packages/package-list.json
+++ b/packages/package-list.json
@@ -503,5 +503,14 @@
     "homepage": "https://www.hyperbrowser.ai/",
     "runtime": "node",
     "license": "MIT"
+  },
+  {
+    "name": "anilist-mcp",
+    "description": "A Model Context Protocol (MCP) server that interfaces with the AniList API, allowing LLM clients to access and interact with anime, manga, character, staff, and user data from AniList.",
+    "vendor": "yuna0x0",
+    "sourceUrl": "https://github.com/yuna0x0/anilist-mcp",
+    "homepage": "https://github.com/yuna0x0/anilist-mcp",
+    "license": "MIT",
+    "runtime": "node"
   }
 ]

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -217,5 +217,13 @@ export const packageHelpers: PackageHelpers = {
         required: true
       },
     }
+  },
+  'anilist-mcp': {
+    requiredEnvVars: {
+      ANILIST_TOKEN: {
+        description: 'Optional API token for AniList',
+        required: false
+      }
+    }
   }
 };


### PR DESCRIPTION
`anilist-mcp` is a mcp server that interfaces with the AniList API, allowing LLM clients to access and interact with anime, manga, character, staff, and user data from AniList.