### PR TITLE
adding canvas mcp to the registry

### DIFF
--- a/packages/package-list.json
+++ b/packages/package-list.json
@@ -503,5 +503,14 @@
     "homepage": "https://www.hyperbrowser.ai/",
     "runtime": "node",
     "license": "MIT"
+  },
+    {
+    "name": "canvas-mcp",
+    "description": "Collection of MCP tools for Canvas LMS. Allows you to query your courses, find resources, and find upcoming assignments in the AI app of your choice",
+    "vendor": "Aryan Keluskar",
+    "sourceUrl": "https://github.com/aryankeluskar/canvas-mcp/",
+    "homepage": "https://github.com/aryankeluskar/canvas-mcp/",
+    "license": "MIT",
+    "runtime": "python"
   }
 ]


### PR DESCRIPTION
Since 2018, Canvas has been the most popular learning management system (LMS) among U.S. colleges and universities. Using AI for education is perceived as unethical since the model guesses the best resources and tends to hallucinate or give irrelevant resources. 

Canvas MCP aims to fix that by supporting Natural Language Querying for professor-provided resources and upcoming assignments. I would love to have this listed in this registry. I have also attached two images as demo for the product. This is completely open-source with an MIT License at https://github.com/aryankeluskar/canvas-mcp/

<img width="1008" alt="cut_example" src="https://github.com/user-attachments/assets/9a2565ff-96a1-44c7-910c-a8291722541b" />