### PR TITLE
Add Chargebee MCP package

### DIFF
--- a/packages/chargebee--mcp.json
+++ b/packages/chargebee--mcp.json
@@ -1,0 +1,10 @@
+{
+  "name": "@chargebee/mcp",
+  "description": "MCP Server that connects AI agents to Chargebee platform.",
+  "vendor": "Chargebee (https://chargebee.com)",
+  "sourceUrl": "https://github.com/chargebee/agentkit/tree/main/modelcontextprotocol",
+  "homepage": "https://chargebee.com",
+  "runtime": "node",
+  "license": "MIT",
+  "environmentVariables": {}
+}

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -225,5 +225,8 @@ export const packageHelpers: PackageHelpers = {
         required: true
       },
     }
+  },
+  '@chargebee/mcp': {
+    requiredEnvVars: {}
   }
 };


### PR DESCRIPTION
This PR adds the Chargebee MCP package to the registry. It builds on the work in #84 but contains only the package file.