### PR TITLE
Add anilist-mcp server

### DIFF
--- a/packages/anilist-mcp.json
+++ b/packages/anilist-mcp.json
@@ -1,0 +1,10 @@
+{
+  "name": "anilist-mcp",
+  "description": "MCP server that interfaces with the AniList API, allowing LLM clients to access and interact with anime, manga, character, staff, and user data from AniList",
+  "vendor": "yuna0x0 (https://github.com/yuna0x0)",
+  "sourceUrl": "https://github.com/yuna0x0/anilist-mcp",
+  "homepage": "https://github.com/yuna0x0/anilist-mcp",
+  "license": "MIT",
+  "runtime": "node",
+  "environmentVariables": {}
+}


### PR DESCRIPTION
This PR adds anilist-mcp server in the new package format, superseding PR #83. The original package information has been preserved and converted to the individual file format.\n\nThe anilist-mcp server interfaces with the AniList API, allowing LLM clients to access and interact with anime, manga, character, staff, and user data from AniList.