### PR TITLE
Add qanon_mcp.json

### DIFF
--- a/packages/qanon_mcp.json
+++ b/packages/qanon_mcp.json
@@ -1,0 +1,10 @@
+{
+  "name": "qanon_mcp",
+  "description": "Enables search, exploration, and analysis of all QAnon posts/drops for sociological study",
+  "vendor": "Jack Kingsman",
+  "sourceUrl": "https://github.com/jkingsman/qanon-mcp-server",
+  "homepage": "https://github.com/jkingsman/qanon-mcp-server",
+  "license": "MIT",
+  "runtime": "python",
+  "environmentVariables": {}
+}


### PR DESCRIPTION
This adds a sociological research tool for analyzing the posts made by the online conspiracy theorist QAnon. As far as I'm aware, there are very few MCPs targeting large-format static data access for textual analysis tuned specifically for its corpus, so I'm eager to see if this might help some people who are currently working on academic work around this cultural phenomenon.