### PR TITLE
Fix PR check for Python packages with specific version requirements

### DIFF
--- a/src/scripts/pr-check.js
+++ b/src/scripts/pr-check.js
@@ -155,9 +155,15 @@ async function validatePackagePublication(pkg) {
     }
   } else if (runtime === 'python') {
     try {
-      execSync(`pip install --dry-run ${name}`, { stdio: 'pipe' });
+      const output = execSync(`pip install --dry-run ${name} 2>&1`, { encoding: 'utf-8' });
+      console.log(`pip install output: ${output}`);
     } catch (error) {
-      throw new Error(`Package ${name} is not published on PyPI. Please publish it first.`);
+      // Check if the error is due to Python version requirements
+      if (error.stdout && error.stdout.includes('Ignored the following versions that require a different python version')) {
+        console.log(`Package ${name} exists on PyPI but requires a different Python version. This is acceptable.`);
+      } else {
+        throw new Error(`Package ${name} is not published on PyPI. Please publish it first.`);
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
This PR updates the PR check script to properly handle Python packages that exist on PyPI but require a different Python version than what's currently available.

## Details
- The script now checks whether a Python package installation failure is specifically due to version requirements
- When a package requires a newer Python version (e.g., Python 3.13), the PR check will now pass rather than failing
- This is particularly useful for packages published on PyPI that target newer Python versions that aren't yet widely available

## Why This Matters
Without this change, PR checks fail for valid packages that are correctly published but have specific Python version requirements. This was causing issues for packages like  in PR #102, which requires Python 3.13.

## Testing
- Tested with packages requiring different Python versions
- Verified that the PR check now correctly identifies packages that exist on PyPI but require a different Python version

Fixes validation issues in PR #102