### PR TITLE
Add OpenAPI Schema Explorer MCP server

### DIFF
--- a/packages/mcp-openapi-schema-explorer.json
+++ b/packages/mcp-openapi-schema-explorer.json
@@ -1,0 +1,10 @@
+{
+  "name": "mcp-openapi-schema-explorer",
+  "description": "MCP server providing token-efficient access to OpenAPI/Swagger specs via MCP Resources for client-side exploration.",
+  "vendor": "Aleksandr Kadykov (https://www.kadykov.com/)",
+  "sourceUrl": "https://github.com/kadykov/mcp-openapi-schema-explorer",
+  "homepage": "https://github.com/kadykov/mcp-openapi-schema-explorer",
+  "license": "MIT",
+  "runtime": "node",
+  "environmentVariables": {}
+}


### PR DESCRIPTION
**Reason for Addition:**

Working with large OpenAPI or Swagger specifications can quickly consume context window limits. This server solves that problem by providing **token-efficient access** to API specs via MCP Resources.

Instead of loading the entire file, users can interactively explore API paths, operations, and components using intuitive URIs (`openapi://...`). It supports local files and remote URLs, automatically handles Swagger v2 conversion, and transforms internal references into clickable links, making API understanding and exploration significantly faster and more context-friendly.
