### PR TITLE
Add Webflow MCP server

### DIFF
--- a/packages/webflow-mcp-server.json
+++ b/packages/webflow-mcp-server.json
@@ -1,0 +1,15 @@
+{
+  "name": "webflow-mcp-server",
+  "description": "Webflow MCP server to help users easily interact with Webflow sites, pages, and collections.",
+  "vendor": "Webflow Inc. (https://webflow.com)",
+  "sourceUrl": "https://github.com/webflow/mcp-server",
+  "homepage": "https://github.com/webflow/mcp-server",
+  "license": "MIT",
+  "runtime": "node",
+  "environmentVariables": {
+    "WEBFLOW_TOKEN": {
+      "description": "API key for Webflow API",
+      "required": true
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the Webflow MCP server package metadata to the mcp-get registry.

About the Package
Name: Webflow MCP Server 
Description: MCP server for creating and updating sites, pages and collections on Webflow
Vendor: Webflow
License: MIT
Runtime: Node.js

Testing
The package has been tested locally with Cursor and works as expected.

