### PR TITLE
Fix HFSpace metadata newline

### DIFF
--- a/packages/llmindset--mcp-hfspace.json
+++ b/packages/llmindset--mcp-hfspace.json
@@ -1,6 +1,6 @@
 {
   "name": "@llmindset/mcp-hfspace",
-  "description": "MCP Server for using HuggingFace Spaces. Seamlessly use the latest Open Source Image, Audio and Text Models from within Claude Deskop.",
+  "description": "MCP Server for using HuggingFace Spaces. Seamlessly use the latest Open Source Image, Audio and Text Models from within Claude Desktop.",
   "vendor": "llmindset.co.uk",
   "sourceUrl": "https://github.com/evalstate/mcp-hfspace/",
   "homepage": "https://llmindset.co.uk/resources/hfspace-connector/",


### PR DESCRIPTION
## Summary
- correct description referencing Claude Desktop
- add trailing newline to HFSpace package metadata
- set repo remote to `https://github.com/michaellatman/mcp-get.git`

## Testing
- `npm run pr-check` *(fails: bad revision 'origin/main')*