### PR TITLE
Add preliminary HTTP server support

### DIFF
--- a/src/extractors/modelcontextprotocol-extractor.ts
+++ b/src/extractors/modelcontextprotocol-extractor.ts
@@ -18,14 +18,14 @@ interface PackageInfo {
   sourceUrl: string;
   homepage: string;
   license: string;
-  runtime: 'node' | 'python' | 'go';
+  runtime: 'node' | 'python' | 'go' | 'http';
 }
 
 interface RepoConfig {
   url: string;
   branch: string;
   packagePath: string;
-  runtime: 'node' | 'python' | 'go' | 'mixed';
+  runtime: 'node' | 'python' | 'go' | 'http' | 'mixed';
 }
 
 interface PyProjectToml {

--- a/src/install.ts
+++ b/src/install.ts
@@ -4,8 +4,8 @@ import inquirer from 'inquirer';
 import chalk from 'chalk';
 import { loadPackage } from './utils/package-registry.js';
 
-async function promptForRuntime(): Promise<'node' | 'python' | 'go'> {
-  const { runtime } = await inquirer.prompt<{ runtime: 'node' | 'python' | 'go' }>([
+async function promptForRuntime(): Promise<'node' | 'python' | 'go' | 'http'> {
+  const { runtime } = await inquirer.prompt<{ runtime: 'node' | 'python' | 'go' | 'http' }>([
     {
       type: 'list',
       name: 'runtime',
@@ -13,14 +13,15 @@ async function promptForRuntime(): Promise<'node' | 'python' | 'go'> {
       choices: [
         { name: 'Node.js', value: 'node' },
         { name: 'Python', value: 'python' },
-        { name: 'Go', value: 'go' }
+        { name: 'Go', value: 'go' },
+        { name: 'HTTP URL', value: 'http' }
       ]
     }
   ]);
   return runtime;
 }
 
-function createUnknownPackage(packageName: string, runtime: 'node' | 'python' | 'go'): Package {
+function createUnknownPackage(packageName: string, runtime: 'node' | 'python' | 'go' | 'http'): Package {
   return {
     name: packageName,
     description: 'Unverified package',
@@ -28,7 +29,8 @@ function createUnknownPackage(packageName: string, runtime: 'node' | 'python' | 
     vendor: '',
     sourceUrl: '',
     homepage: '',
-    license: ''
+    license: '',
+    url: runtime === 'http' ? packageName : undefined
   };
 }
 
@@ -38,10 +40,17 @@ export async function installPackage(pkg: Package): Promise<void> {
 
 export async function install(packageName: string): Promise<void> {
   const pkg = loadPackage(packageName);
+  const isUrl = /^https?:\/\//.test(packageName);
 
   if (!pkg) {
+    if (isUrl) {
+      const httpPkg = createUnknownPackage(packageName, 'http');
+      await installPkg(httpPkg);
+      return;
+    }
+
     console.warn(chalk.yellow(`Package ${packageName} not found in the curated list.`));
-    
+
     const { proceedWithInstall } = await inquirer.prompt<{ proceedWithInstall: boolean }>([
       {
         type: 'confirm',
@@ -53,10 +62,10 @@ export async function install(packageName: string): Promise<void> {
 
     if (proceedWithInstall) {
       console.log(chalk.cyan(`Proceeding with installation of ${packageName}...`));
-      
+
       // Prompt for runtime for unverified packages
       const runtime = await promptForRuntime();
-      
+
       // Create a basic package object for unverified packages
       const unknownPkg = createUnknownPackage(packageName, runtime);
       await installPkg(unknownPkg);

--- a/src/types/package.ts
+++ b/src/types/package.ts
@@ -1,11 +1,13 @@
 export interface Package {
     name: string;
     description: string;
-    runtime: 'node' | 'python' | 'go';
+    runtime: 'node' | 'python' | 'go' | 'http';
     vendor: string;
     sourceUrl: string;
     homepage: string;
     license: string;
+    /** Optional URL for HTTP based servers */
+    url?: string;
     version?: string; // Optional version field to specify package version
     environmentVariables?: {
         [key: string]: {
@@ -30,7 +32,7 @@ export interface PackageHelper {
         }
     };
     configureEnv?: (config: any) => Promise<void>;
-    runtime?: 'node' | 'python' | 'go';
+    runtime?: 'node' | 'python' | 'go' | 'http';
 }
 
 export interface PackageHelpers {

--- a/src/utils/__tests__/config-manager.test.ts
+++ b/src/utils/__tests__/config-manager.test.ts
@@ -57,6 +57,17 @@ describe('ConfigManager', () => {
     license: 'MIT'
   };
 
+  const httpPackage: Package = {
+    name: 'https://example.com/server',
+    description: 'Test http package',
+    runtime: 'http',
+    vendor: 'test-vendor',
+    sourceUrl: 'https://example.com',
+    homepage: 'https://example.com',
+    license: 'MIT',
+    url: 'https://example.com/server'
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
     
@@ -226,6 +237,18 @@ describe('ConfigManager', () => {
       expect(writtenConfig.mcpServers['test-python-pkg'].runtime).toBe('python');
       expect(writtenConfig.mcpServers['test-python-pkg'].command).toBe('uvx');
       expect(writtenConfig.mcpServers['test-python-pkg'].args).toEqual(['test-python-pkg']);
+    });
+
+    it('should add HTTP package to config', async () => {
+      await ConfigManager.installPackage(httpPackage);
+
+      const writeSpy = jest.spyOn(fs, 'writeFileSync');
+      const writtenConfig = JSON.parse(writeSpy.mock.calls[0][1] as string);
+
+      const key = 'https://example.com/server'.replace(/\//g, '-');
+      expect(writtenConfig.mcpServers[key]).toBeDefined();
+      expect(writtenConfig.mcpServers[key].runtime).toBe('http');
+      expect(writtenConfig.mcpServers[key].url).toBe('https://example.com/server');
     });
     
     it('should include environment variables if provided', async () => {

--- a/src/utils/config-manager.ts
+++ b/src/utils/config-manager.ts
@@ -4,10 +4,11 @@ import os from 'os';
 import { Package } from '../types/package.js';
 
 export interface MCPServer {
-    runtime: 'node' | 'python' | 'go';
+    runtime: 'node' | 'python' | 'go' | 'http';
     command?: string;
     args?: string[];
     env?: Record<string, string>;
+    url?: string;
     version?: string; // Add version field to track installed version
 }
 
@@ -116,8 +117,10 @@ export class ConfigManager {
             version: pkg.version // Store version information
         };
 
-        // Add command and args based on runtime and version
-        if (pkg.runtime === 'node') {
+        // Add command, args or url based on runtime and version
+        if (pkg.runtime === 'http') {
+            serverConfig.url = pkg.url || pkg.name;
+        } else if (pkg.runtime === 'node') {
             serverConfig.command = 'npx';
             serverConfig.args = ['-y', pkg.version ? `${pkg.name}@${pkg.version}` : pkg.name];
         } else if (pkg.runtime === 'python') {


### PR DESCRIPTION
## Summary
- extend runtime type to include `http`
- allow packages to specify `url` for HTTP-based servers
- handle HTTP runtime in install commands and config management
- add tests for HTTP package handling

## Testing
- `npm install` *(fails: EHOSTUNREACH)*
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find eslint plugin)*