### PR TITLE
Add jobgpt-mcp-server package

### DIFF
--- a/packages/jobgpt-mcp-server.json
+++ b/packages/jobgpt-mcp-server.json
@@ -1,0 +1,15 @@
+{
+  "name": "jobgpt-mcp-server",
+  "description": "MCP server for JobGPT - search jobs, auto-apply, generate tailored resumes, track applications, and find recruiters",
+  "vendor": "6figr.com (https://github.com/6figr-com)",
+  "sourceUrl": "https://github.com/6figr-com/jobgpt-mcp-server",
+  "homepage": "https://www.npmjs.com/package/jobgpt-mcp-server",
+  "license": "MIT",
+  "runtime": "node",
+  "environmentVariables": {
+    "JOBGPT_API_KEY": {
+      "description": "API key for JobGPT authentication. Get yours at https://6figr.com/account",
+      "required": true
+    }
+  }
+}


### PR DESCRIPTION
Adds [jobgpt-mcp-server](https://github.com/6figr-com/jobgpt-mcp-server) to the mcp-get registry.

JobGPT is an MCP server for AI-powered job search and application management with 34 tools covering job search, auto-apply, resume generation, application tracking, and recruiter outreach.

- npm: [jobgpt-mcp-server](https://www.npmjs.com/package/jobgpt-mcp-server)
- Website: [6figr.com/jobgpt](https://6figr.com/jobgpt)