### PR TITLE
Add @jtalk22/slack-mcp server

### DIFF
--- a/packages/jtalk22--slack-mcp.json
+++ b/packages/jtalk22--slack-mcp.json
@@ -1,0 +1,19 @@
+{
+  "name": "@jtalk22/slack-mcp",
+  "description": "Session-based Slack MCP for Claude. Read channels, search messages, send messages, get AI summaries. Cloud hosted option available.",
+  "vendor": "Revasser Labs (https://revasser.nyc)",
+  "sourceUrl": "https://github.com/jtalk22/slack-mcp-server",
+  "homepage": "https://jtalk22.github.io/slack-mcp-server/",
+  "license": "MIT",
+  "runtime": "node",
+  "environmentVariables": {
+    "SLACK_TOKEN": {
+      "description": "Slack xoxc- token from browser session",
+      "required": false
+    },
+    "SLACK_COOKIE": {
+      "description": "Slack xoxd- cookie from browser session",
+      "required": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds `@jtalk22/slack-mcp` — a session-based Slack MCP server for Claude and MCP clients.

- **npm:** `npx -y @jtalk22/slack-mcp`
- **GitHub:** https://github.com/jtalk22/slack-mcp-server
- **Cloud hosted:** https://mcp.revasserlabs.com/oauth/mcp (OAuth 2.1)
- **Tools:** 13 (10 standard + 3 AI compound)
- **License:** MIT
- **npm weekly downloads:** [npmjs.com/package/@jtalk22/slack-mcp](https://www.npmjs.com/package/@jtalk22/slack-mcp)

Differentiators from the official `@modelcontextprotocol/server-slack`:
- Works with browser session tokens (no admin-installed OAuth app needed)
- Cloud hosted option (no Docker/self-hosting)
- AI compound tools (channel summaries, action items, decision extraction)
- Privacy policy at https://jtalk22.github.io/slack-mcp-server/privacy.html