### PR TITLE
Add evc-spark-mcp package

### DIFF
--- a/packages/evc-spark-mcp.json
+++ b/packages/evc-spark-mcp.json
@@ -1,0 +1,10 @@
+{
+  "name": "evc-spark-mcp",
+  "description": "MCP server for Spark — search and install curated AI agent workflows, skills, prompts, and MCP connectors from a marketplace of 4,500+ assets",
+  "vendor": "Entire VC (https://entire.vc)",
+  "sourceUrl": "https://github.com/entire-vc/evc-spark-mcp",
+  "homepage": "https://spark.entire.vc",
+  "license": "MIT",
+  "runtime": "node",
+  "environmentVariables": {}
+}


### PR DESCRIPTION
## Summary

Adds [evc-spark-mcp](https://github.com/entire-vc/evc-spark-mcp) to the mcp-get registry.

**Spark** is an AI asset marketplace with 4,500+ curated assets (agents, skills, prompts, MCP connectors). This MCP server lets AI assistants search, discover, and install workflows from the catalog.

- **npm:** `evc-spark-mcp`
- **5 tools:** `search_assets`, `get_asset`, `get_asset_content`, `list_popular`, `list_categories`
- **2 resources:** `spark://assets/{slug}`, `spark://catalog/{type}`
- **License:** MIT