### PR TITLE
Add @rendoc/mcp-server — PDF generation MCP server

### DIFF
--- a/packages/@rendoc/mcp-server.json
+++ b/packages/@rendoc/mcp-server.json
@@ -1,0 +1,15 @@
+{
+  "name": "@rendoc/mcp-server",
+  "description": "Generate PDF documents from HTML templates and data via MCP",
+  "vendor": "rendoc (https://rendoc.dev)",
+  "sourceUrl": "https://github.com/yoryocoruxo-ai/rendoc",
+  "homepage": "https://rendoc.dev",
+  "license": "MIT",
+  "runtime": "node",
+  "environmentVariables": {
+    "RENDOC_API_KEY": {
+      "description": "API key for rendoc API",
+      "required": true
+    }
+  }
+}


### PR DESCRIPTION
## Add @rendoc/mcp-server

**rendoc** — Generate PDF documents from HTML templates and data via MCP.

- **npm**: `@rendoc/mcp-server`
- **GitHub**: https://github.com/yoryocoruxo-ai/rendoc
- **Website**: https://rendoc.dev

### Tools

| Tool | Description |
|------|-------------|
| `generate_document` | Generate a PDF from a template and data |
| `list_templates` | List available templates |
| `preview_template` | Preview a template with sample data |
| `create_template` | Create a new HTML template |
| `delete_template` | Delete an existing template |
| `get_document` | Retrieve a previously generated document |
| `get_usage` | Get API usage statistics |

### Setup

```json
{
  "mcpServers": {
    "rendoc": {
      "command": "npx",
      "args": ["-y", "@rendoc/mcp-server"],
      "env": { "RENDOC_API_KEY": "your-api-key" }
    }
  }
}
```