### PR TITLE
feat: add misarmail-mcp-server

### DIFF
--- a/packages/misarmail-mcp-server.json
+++ b/packages/misarmail-mcp-server.json
@@ -1,0 +1,15 @@
+{
+  "name": "misarmail-mcp-server",
+  "description": "MisarMail MCP Server \u2014 32 tools for AI email marketing: send campaigns, manage contacts, check deliverability (DMARC/SPF/DKIM/warmup), A-B test, automate workflows, and run analytics.",
+  "vendor": "Misar AI / G1 Technologies",
+  "sourceUrl": "https://github.com/mrgulshanyadav/misarmail-mcp",
+  "homepage": "https://docs.misar.io/mail/mcp",
+  "license": "MIT",
+  "runtime": "node",
+  "environmentVariables": {
+    "MISARMAIL_API_KEY": {
+      "description": "MisarMail API key (msk_ prefix). Get yours at mail.misar.io/settings/api-keys.",
+      "required": true
+    }
+  }
+}


### PR DESCRIPTION
Adds `misarmail-mcp-server` to the mcp-get registry.

**Package:** https://www.npmjs.com/package/misarmail-mcp-server
**GitHub:** https://github.com/mrgulshanyadav/misarmail-mcp
**Docs:** https://docs.misar.io/mail/mcp

**What it does:** 32 MCP tools for AI email marketing — send campaigns, manage contacts, check deliverability (DMARC/SPF/DKIM/warmup), A-B test, automate workflows, and run analytics.

**Runtime:** node
**License:** MIT
**Freemium:** free tier at mail.misar.io

Install: `npx misarmail-mcp-server --api-key msk_YOUR_KEY`